### PR TITLE
Fix stepper control problems with 20MHz CPU frequency.

### DIFF
--- a/Marlin/planner.cpp
+++ b/Marlin/planner.cpp
@@ -658,7 +658,7 @@ void plan_buffer_line(const float &x, const float &y, const float &z, const floa
       block->acceleration_st = axis_steps_per_sqr_second[Z_AXIS];
   }
   block->acceleration = block->acceleration_st / steps_per_mm;
-  block->acceleration_rate = (long)((float)block->acceleration_st * 8.388608);
+  block->acceleration_rate = (long)((float)block->acceleration_st * (16777216.0 / (F_CPU / 8.0)));
   
 #if 0  // Use old jerk for now
   // Compute path unit vector


### PR DESCRIPTION
Fixes https://github.com/reprappro/Marlin/issues/7 .
