### PR TITLE
Fix compilation on Arduino 1.0.

### DIFF
--- a/Marlin/Marlin.h
+++ b/Marlin/Marlin.h
@@ -31,11 +31,7 @@
 #include "pins.h"
 
 #if ARDUINO >= 100 
-  #if defined(__AVR_ATmega644P__) || defined (__AVR_ATmega1284P__)
-    #include "WProgram.h"
-  #else
-    #include "Arduino.h"
-  #endif
+   #include "Arduino.h"
 #else
    #include "WProgram.h"
 #endif


### PR DESCRIPTION
This fixes https://github.com/reprappro/Marlin/issues/2 . I don't see any reason for the existence of the check that is being removed; the Arduino release notes clearly say that WProgram.h was renamed to Arduino.h in Arduino 1.0.

I've tested this to work with Arduino 1.0.4 and the official Sanguino support files. However, I've noticed that the _bootloader_ from this setup doesn't work (endstops not working); the old bootloader from 0023 still needs to be used (or kept in place).
