### PR TITLE
Fix data overflow problem

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -9,7 +9,7 @@
 
 // Uncomment ONE of the next three lines - the one for your RepRap machine
 //#define REPRAPPRO_HUXLEY
-//#define REPRAPPRO_MENDEL //Legacy Mendel
+#define REPRAPPRO_MENDEL //Legacy Mendel
 //#define REPRAPPRO_MENDEL2 //Tricolour and Mono
 
 // Uncomment ONE of the next two lines - the one for your master controller electronics
@@ -17,8 +17,8 @@
 //#define REPRAPPRO_SANGUINOLOLU
 
 // Uncomment ONE of the next two lines - the one for the series resistors on your controller
-#define SERIAL_R 4700
-//#define SERIAL_R 10000
+//#define SERIAL_R 4700
+#define SERIAL_R 10000
 
 // Uncomment the next line if your machine has more than one extruder
 //#define REPRAPPRO_MULTIMATERIALS
@@ -112,9 +112,9 @@
 
 #ifdef REPRAPPRO_MENDEL
 // Bed thermistor: RS 484-0149; EPCOS B57550G103J
-#define BED_BETA 3480.0
+#define BED_BETA 3960.0
 #define BED_RS SERIAL_R
-#define BED_NTC 10000.0
+#define BED_NTC 100000.0
 #define BED_R_INF ( BED_NTC*exp(-BED_BETA/298.15) )
 
 #endif

--- a/Marlin/EEPROMwrite.h
+++ b/Marlin/EEPROMwrite.h
@@ -241,7 +241,8 @@ inline void EEPROM_RetrieveSettings(bool def=false)
         axis_steps_per_unit[i]=tmp1[i];  
         max_feedrate[i]=tmp2[i];  
         max_acceleration_units_per_sq_second[i]=tmp3[i];
-        max_length[i]=tmp4[i];
+        if(i<sizeof(tmp4)/sizeof(tmp4[0]))
+            max_length[i]=tmp4[i];
       }
       acceleration=DEFAULT_ACCELERATION;
       retract_acceleration=DEFAULT_RETRACT_ACCELERATION;

--- a/Marlin/pins.h
+++ b/Marlin/pins.h
@@ -97,7 +97,7 @@
 
 #define LED_PIN            27
 
-#define FAN_PIN            4 
+#define FAN_PIN            6 
 
 #define PS_ON_PIN          -1
 #define KILL_PIN           -1
@@ -118,7 +118,7 @@
 #define TEMP_0_PIN          7   // MUST USE ANALOG INPUT NUMBERING NOT DIGITAL OUTPUT NUMBERING!!!!!!!!! (pin 33 extruder)
 #define TEMP_1_PIN         -1
 #define TEMP_2_PIN         -1
-#define TEMP_BED_PIN        6   // MUST USE ANALOG INPUT NUMBERING NOT DIGITAL OUTPUT NUMBERING!!!!!!!!! (pin 34 bed)
+#define TEMP_BED_PIN        4   // MUST USE ANALOG INPUT NUMBERING NOT DIGITAL OUTPUT NUMBERING!!!!!!!!! (pin 34 bed)
 #define SDPOWER            -1
 #define SDSS               31
 


### PR DESCRIPTION
The size of max_length is 3 but the loop is 4, so writing to max_length overrides other variables (in my case, exetudemultiply), which causes problems.
